### PR TITLE
Erro lendo as planilhas: File is not a zip file

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -12,7 +12,7 @@ def download(url, file_path, year, month):
     try:
       response = requests.get(url, allow_redirects=True)
     #   Quando o órgão não publica dados, o coletor baixa o html que retorna '404 Not Found'
-      if '404 Not Found' in response.text:
+      if response.status_code == 404:
           sys.stderr.write(f"Não existe planilhas para {month}/{year}.")
           sys.exit(4)
       with open(file_path, "wb") as file:

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -8,9 +8,13 @@ URL_FORMATS = { 'membros-ativos-contracheque': 'http://apps.mppr.mp.br/planilhas
                 'membros-ativos-verbas-indenizatorias': 'http://apps.mppr.mp.br/planilhas_transparencia/mptransp{}{}mavio.ods'
         }
     
-def download(url, file_path):
+def download(url, file_path, year, month):
     try:
       response = requests.get(url, allow_redirects=True)
+    #   Quando o órgão não publica dados, o coletor baixa o html que retorna '404 Not Found'
+      if '404 Not Found' in response.text:
+          sys.stderr.write(f"Não existe planilhas para {month}/{year}.")
+          sys.exit(4)
       with open(file_path, "wb") as file:
           file.write(response.content)
       file.close()
@@ -27,7 +31,7 @@ def crawl(year, month, output_path):
         filename = f'{key}-{month}-{year}.ods'
         file_path = f'{output_path}/{filename}'
         url = URL_FORMATS[key].format(year, month)
-        download(url, file_path)
+        download(url, file_path, year, month)
         
         files.append(file_path)
         


### PR DESCRIPTION
Quando o órgão não publica dados, o coletor baixa o html que retorna '404 Not Found', sendo que o tipo esperado é ODS.